### PR TITLE
Edit headers for repubblica.it

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,25 @@
+const fixHeaders = ({requestHeaders}) => {
+    requestHeaders = requestHeaders.filter(h => ! ["referer", "cookie"].includes(h.name.toLowerCase()))
+    requestHeaders.push({
+        name: "Referer",
+        value: "https://m.google.it/"
+    })
+    return {requestHeaders}
+}
+
+const filters = {
+    urls: [ "https://*.repubblica.it/*" ],
+    types: [ "main_frame" ]
+}
+const opts = [ "blocking", "requestHeaders" ]
+
+try {
+    void browser
+} catch (e) {
+    if (e instanceof ReferenceError && typeof chrome != "undefined") {
+        browser = chrome
+        opts.push("extraHeaders")
+    }
+}
+
+browser.webRequest.onBeforeSendHeaders.addListener(fixHeaders, filters, opts)

--- a/freeRep.js
+++ b/freeRep.js
@@ -27,6 +27,8 @@ const isNewPaywall = el => checkClassName(el, "paywall__content")
 const isGazzettaPaywall = el => checkClassName(el, "bck-freemium__wall")
 const isGazzettaPartnerLink = el => checkClassName(el, "is-partner-link")
 const isGazzettaContent = el => checkAttr(el, "class", "content") // exact match
+
+const isRepubblica = () => location.host.endsWith("repubblica.it")
 const isLaStampa = () => location.host.endsWith("lastampa.it")
 const isGazzettaIt = () => location.host.endsWith("gazzetta.it")
 
@@ -82,7 +84,10 @@ const tryFindNode = (root, predicate, timeout =50, tlimit =5000) => new Promise(
 
 const freeRep = () => {
     if (!window.location.pathname.endsWith("/amp/")) {
-        if (isGazzettaIt()) {
+        if (isRepubblica()) {
+            // Do nothing, the background script will handle that.
+            // TODO: GM_* ?
+        } else if (isGazzettaIt()) {
             [isGazzettaPaywall, isGazzettaPartnerLink].forEach(p => {
                 const el = findNode(document, p)
                 if (el) {

--- a/freeRep.js
+++ b/freeRep.js
@@ -85,7 +85,7 @@ const tryFindNode = (root, predicate, timeout =50, tlimit =5000) => new Promise(
 const freeRep = () => {
     if (!window.location.pathname.endsWith("/amp/")) {
         if (isRepubblica()) {
-            // Do nothing, the background script will handle that.
+            hide(findNode(document, isNewPaywall))
             // TODO: GM_* ?
         } else if (isGazzettaIt()) {
             [isGazzettaPaywall, isGazzettaPartnerLink].forEach(p => {

--- a/makedist.sh
+++ b/makedist.sh
@@ -4,4 +4,5 @@ set -x
 zip -rX -FS ./freeRep.zip \
     manifest.json \
     freeRep.js \
+    background.js \
     icons/*.png

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,11 @@
   "icons": {
     "48": "icons/freeRep-48.png"
   },
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "https://*.repubblica.it/*"
+  ],
   "content_scripts": [
     {
       "matches": [
@@ -18,5 +23,10 @@
         "freeRep.js"
       ]
     }
-  ]
+  ],
+  "background": {
+    "scripts": [
+      "background.js"
+    ]
+  }
 }


### PR DESCRIPTION
Added a backgound script to manipulate the HTTP request for repubblica.it

After #14 I discovered that if there's something like google in the `Referer` header, repubblica.it disables the paywall (LOL).
I set "m.google.it" that looks somewhat legit, but really you can use "bypass.paywall.google.xxx" and it would work as well.

I'm disabling the Cookie header, because it looks they check this one as well... I'm not very proud of this, because the user could do that from the browser itself (I already do that for corriere.it), but whatever.

It should work on Firefox and Chrome-based browsers.
Tamper/GreaseMonkey requires a different approach. Unless someone is willing to make this code work with GM_* thingies, I reckon we should drop the support.

Please take a look at the changes and test it.